### PR TITLE
cedar alpha example

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -9,7 +9,7 @@
       "type": "string",
       "required": true,
       "label": "Project description",
-      "default": "An REI Cedar component built on Vue.js "
+      "default": "An REI FED component built on Vue.js and Cedar"
     },
     "author": {
       "type": "string",

--- a/template/package.json
+++ b/template/package.json
@@ -11,14 +11,9 @@
     "lint": "eslint --ext .js,.vue src",
     "build": "node build/build.js"
   },
-  "dependencies": {
-    "@rei/cdr-accordion": "^1.0.4",
-    "@rei/cdr-assets": "^0.3.0",
-    "@rei/cdr-button": "^2.0.0",
-    "@rei/cdr-cta": "^1.1.1",
-    "@rei/cdr-icon": "^2.0.1",
-    "@rei/cdr-text": "^1.0.2",
-    "@rei/cdr-tokens": "^0.1.8",
+  "peerDependencies": {
+    "@rei/cedar": "^1.0.0-alpha.1",
+    "@rei/cdr-tokens": "^1.0.0",
     "vue": "^2.5.11"
   },
   "browserslist": [
@@ -27,6 +22,8 @@
     "not ie <= 8"
   ],
   "devDependencies": {
+    "@rei/cedar": "^1.0.0-alpha.1",
+    "@rei/cdr-tokens": "^1.0.0",
     "autoprefixer": "^7.1.2",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.1",
@@ -66,6 +63,7 @@
     "shelljs": "^0.7.6",
     "uglifyjs-webpack-plugin": "^1.1.1",
     "url-loader": "^0.5.8",
+    "vue": "^2.5.11",
     "vue-loader": "^13.3.0",
     "vue-style-loader": "^3.1.2",
     "vue-template-compiler": "^2.5.2",

--- a/template/src/SampleComponent.vue
+++ b/template/src/SampleComponent.vue
@@ -1,15 +1,13 @@
 <script>
-import { CdrText } from '@rei/cdr-text';
-import { CdrButton } from '@rei/cdr-button';
-import { IconCheckFill, IconXFill } from '@rei/cdr-icon';
+import { CdrText, CdrButton, CdrIcon } from '@rei/cedar';
 import SampleChildComponent from './components/SampleChildComponent';
 
 export default {
   name: 'SampleComponent',
   components: {
     CdrButton,
-    IconCheckFill,
-    IconXFill,
+    IconCheckFill: CdrIcon.IconCheckFill,
+    IconXFill: CdrIcon.IconXFill,
     CdrText,
     SampleChildComponent,
   },
@@ -83,10 +81,9 @@ export default {
   </div>
 </template>
 <style lang="scss">
-  @import '~@rei/cdr-tokens/dist/cdr-tokens.scss';
-  .cdr-button {
-    &__icon {
-      fill: $clean-slate;
-    }
+  @import '~@rei/cdr-tokens/dist/scss/cdr-tokens.scss';
+
+  .sample-component {
+    padding: $cdr-space-inset-one-x;
   }
 </style>

--- a/template/src/components/SampleChildComponent.vue
+++ b/template/src/components/SampleChildComponent.vue
@@ -1,6 +1,5 @@
 <script>
-import { CdrAccordion, CdrAccordionItem } from '@rei/cdr-accordion';
-import { CdrText } from '@rei/cdr-text';
+import { CdrAccordion, CdrAccordionItem, CdrText } from '@rei/cedar';
 
 export default {
   name: 'SampleChildComponent',


### PR DESCRIPTION
WIP PR, this should not be merged until after next Cedar release. (and will need to merge these Cedar changes with this PR: https://github.com/rei/component/pull/19/files)

- move vue/cedar to peerDependencies
- update cedar and tokens versions
- update cedar component imports to new single package style
- update cedar tokens import and example 

This matches the way that climber-details-page and climbers-site are being built, and should make it easy for us to de-dupe and tree-shake out the un-used parts of cedar. 


