### PR TITLE
add prepare script for jenkins

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -20,6 +20,7 @@
     "start": "npm run dev",
     "lint": "eslint --ext .js,.vue src",
     "prebuild": "rimraf dist index.css",
+    "prepare": "npm run build",
     "build": "cross-env NODE_ENV=production BABEL_ENV=es rollup -c",
     "test": "cross-env BABEL_ENV=test nyc --all vunit --spec=./test/**/*.spec.js",
     "test-coverage": "npm run test-js-coverage && npm run test-vue-coverage",


### PR DESCRIPTION
It seems that Jenkins needs this script to run the actual `npm build` script and not just an internal `build.js` script defined (I think) in that workspace.
Without this script, only the `src` directories get packaged on the tars in the private registry