### PR TITLE
add dev header and update meta

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -27,6 +27,12 @@ module.exports = {
       type: 'string',
       label: 'Author',
     },
+    addHeaderFooter: {
+      type: 'boolean',
+      required: true,
+      label: 'Include dev header/footer?',
+      default: true,
+    },
     addComponents: {
       type: 'boolean',
       required: true,

--- a/template/index.html
+++ b/template/index.html
@@ -5,35 +5,16 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <link rel="stylesheet" href="dist/app.bundle.css">
+  {{#if_eq addHeaderFooter true}}
+  <link href="https://future.rei.com/static/global/head/rei-cedar.min.css" rel="stylesheet">
+  <link href="https://future.rei.com/static/legacy-nav/main.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:400|Roboto:400,700" rel="stylesheet">
+  {{/if_eq}}
   <title>{{ name }}</title>
 </head>
 
-<body class="cdr-inset">
-  <main-component
-    id="app" title="{{name}}"
-    description="{{description}}"
-    {{#if_eq addComponents true}}
-      accordion-label=" Example child component label"
-      :faqs="[
-        {
-          question: 'How do i do this?',
-          answer: 'This is how.',
-          id: '1',
-        },
-        {
-          question: 'When?',
-          answer: 'The time is now.',
-          id: '2',
-
-        },
-        {
-          question: 'Where?',
-          answer: 'Anywhere you can make it happen.',
-          id: '3',
-        },
-      ]"
-    {{/if_eq}}>
-  </main-component>
+<body>
+  <div id="app"></div>
   <script src="dist/app.bundle.js"></script>
 </body>
 

--- a/template/local-development.js
+++ b/template/local-development.js
@@ -1,4 +1,7 @@
 import Vue from 'vue';
+{{#if_eq addHeaderFooter true}}
+import HeaderFooter from '@rei/dev-header-footer'
+{{/if_eq}}
 
 /* Bring in external style sheets here that aren't explicitly imported elsewhere.
  * This file is only for local dev and does not generate any distribution CSS bundles
@@ -20,9 +23,41 @@ import './dist/index.css'
 import MainComponent from '.';
 
 Vue.config.productionTip = false;
+const options = {
+  title: '{{name}}',
+  description: '{{description}}',
+  {{#if_eq addComponents true}}
+  accordionLabel: 'Example child component label',
+  faqs: [
+    {
+    question: 'How do i do this?',
+    answer: 'This is how.',
+    id: '1',
+    },
+    {
+    question: 'When?',
+    answer: 'The time is now.',
+    id: '2',
+
+    },
+    {
+    question: 'Where?',
+    answer: 'Anywhere you can make it happen.',
+    id: '3',
+   },
+  ]
+  {{/if_eq}}
+}
 
 /* eslint-disable no-new */
 new Vue({
   el: '#app',
-  components: { MainComponent },
+  render(h){
+    {{#if_eq addHeaderFooter true}}
+    return h(HeaderFooter, [h(MainComponent, { class: 'container', props: { ...options } })])
+    {{/if_eq}}
+    {{#if_eq addHeaderFooter false}}
+    return h(MainComponent, { props: { ...options } })
+    {{/if_eq}}
+  }
 });

--- a/template/package.json
+++ b/template/package.json
@@ -44,6 +44,12 @@
     "vue": "^2.6.10"
   },
   "devDependencies": {
+    {{#if_eq addHeaderFooter true}}
+    "@rei/dev-header-footer": "0.0.3",
+    "apicache": "^1.4.0",
+    "isomorphic-fetch": "^2.2.1",
+    "morgan": "^1.9.1",
+    {{/if_eq}}
     "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "@babel/runtime": "^7.4.4",

--- a/template/webpack.overrides.conf.js
+++ b/template/webpack.overrides.conf.js
@@ -13,4 +13,43 @@ module.exports = {
       },
     ],
   },
+  devServer: {
+    open: true,
+  {{#if_eq addHeaderFooter true}}
+    before(app) {
+      const fetch = require('isomorphic-fetch');
+      const apicache = require('apicache');
+
+      // apicache is used to store the header/footer markup in memory
+      const cache = apicache.options({
+        debug: true,
+      }).middleware;
+
+      app.use(require('morgan')('dev')); // used for logging
+
+      // fetch and cache markup using express endpoints
+      app.get('/footer', cache(), (req, res) => {
+        fetch(
+          'https://tcommon-components-site.rei-cloud.com/rs/components/common/navigation/footer/shop'
+        )
+          .then(data => data.text())
+          .then(body => res.send(body));
+      });
+      app.get('/unav', cache(), (req, res) => {
+        fetch(
+          'https://tcommon-components-site.rei-cloud.com/rs/components/common/navigation/universal/shop'
+        )
+          .then(data => data.text())
+          .then(body => res.send(body));
+      });
+      app.get('/gnav', cache(), (req, res) => {
+        fetch(
+          'https://tcommon-components-site.rei-cloud.com/rs/components/common/navigation/global/shop'
+        )
+          .then(data => data.text())
+          .then(body => res.send(body));
+      });
+    },
+    {{/if_eq}}
+  },
 };


### PR DESCRIPTION
Add option to pull in a dev header/footer site frame from the reusable FED components repo.
Update Vue templates, webpack overrides for the proxied endpoints, and refactor sample component options to be programmatic instead of stored in html