### PR TITLE
update rollup config for SFC scoped styles

### DIFF
--- a/template/rollup.config.js
+++ b/template/rollup.config.js
@@ -53,17 +53,19 @@ export default {
       extract: path.resolve('./dist/index.css'),
       inject: false,
       plugins: [autoprefixer()],
-      modules: {
-        generateScopedName:
-          process.env.NODE_ENV === 'dev'
-            ? '[name]-[local]'
-            : '[md5:hash:base64:16]',
-      },
+      // uncomment the modules property if you want to import css module files into your js instead of SFC styles
+      // modules: {
+      //   generateScopedName:
+      //     process.env.NODE_ENV === 'dev'
+      //       ? '[name]-[local]'
+      //       : '[md5:hash:base64:16]',
+      // },
     }),
     VuePlugin({
       css: false,
-      template: {
-        isProduction: true,
+      style: {
+        generateScopedName:
+          process.env.NODE_ENV === 'dev' ? '[name]-[local]' : '[md5:hash:base64:16]',
       },
     }),
   ],


### PR DESCRIPTION
Current implementation causes `postcss` to hijack naming conventions for SFC scoped styles. This moves the postcss module logic to the Vue rollup plugin for `style` blocks that have the `module` attribute set to true, and leaves it alone for standard `scoped` style blocks