### PR TITLE
add back build option

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -16,7 +16,8 @@ This project loads [@rei/cedar components](https://github.com/rei/rei-cedar) and
 
 ### Build system
 
-This component only contains a build system for it's dev and test environments. It expects that the micro-site consuming it will handle building it using [@rei/febs](https://github.com/rei/febs).
+This component only contains a build system for distribution and another for development.
+`rollup` is used for distribution, as `webpack` does not currently export `ES6` modules. `febs` is used for the local dev server as it is anticipated the final application will be bundled using `febs`.
 
 ## Local Development
 ``` bash
@@ -34,6 +35,9 @@ npm run dev:clean
 
 # lint files with es-lint
 npm run lint
+
+# build for production with minification with rollup
+npm run build
 
 # run unit tests from files in /test with filenames *.spec.js
 npm run test
@@ -65,6 +69,7 @@ npm run test
 │   └── // spec files and test utilities
 ├── package-lock.json
 ├── package.json
+├── rollup.config.js
 ├── febs-config.json
 └── webpack.overrides.conf.js
 ```

--- a/template/package.json
+++ b/template/package.json
@@ -3,7 +3,9 @@
   "description": "{{ description }}",
   "author": "{{ author }}",
   "version": "0.0.1",
-  "main": "src/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "style": "dist/index.css",
   "files": [
     "dist",
     "src"
@@ -11,9 +13,14 @@
   "browserslist": "extends @rei/browserslist-config",
   "license": "UNLICENSED",
   "scripts": {
-    "dev": "cross-env NODE_ENV=dev febs dev --watch",
+    "dev:server": "cross-env NODE_ENV=dev febs dev",
+    "dev:build": "cross-env NODE_ENV=dev BABEL_ENV=es rollup -c --watch",
+    "dev:clean": "rimraf dist && npm run dev",
+    "dev": "npm-run-all -p dev:build dev:server",
     "start": "npm run dev",
     "lint": "eslint --ext .js,.vue src",
+    "prebuild": "rimraf dist index.css",
+    "build": "cross-env NODE_ENV=production BABEL_ENV=es rollup -c",
     "test": "cross-env BABEL_ENV=test nyc --all vunit --spec=./test/**/*.spec.js",
     "test-coverage": "npm run test-js-coverage && npm run test-vue-coverage",
     "test-js": "cross-env BABEL_ENV=test mocha --require babel-register --recursive src/main/js/test/**/*.spec.js",
@@ -50,7 +57,13 @@
     "eslint-plugin-vue": "^5.2.2",
     "npm-run-all": "^4.1.5",
     "postcss-url": "^8.0.0",
-    "rimraf": "^2.6.0"
+    "rimraf": "^2.6.0",
+    "rollup": "^1.11.0",
+    "rollup-plugin-babel": "^4.3.2",
+    "rollup-plugin-commonjs": "^9.3.4",
+    "rollup-plugin-node-resolve": "^4.2.3",
+    "rollup-plugin-postcss": "^2.0.3",
+    "rollup-plugin-vue": "^5.0.1"
   },
   "nyc": {
     "include": [

--- a/template/rollup.config.js
+++ b/template/rollup.config.js
@@ -1,0 +1,73 @@
+/* eslint-env node */
+import resolve from 'rollup-plugin-node-resolve';
+import postcss from 'rollup-plugin-postcss';
+import babel from 'rollup-plugin-babel';
+import path from 'path';
+import autoprefixer from 'autoprefixer';
+import rollupPluginCommonjs from 'rollup-plugin-commonjs';
+import packageJson from './package.json';
+import VuePlugin from 'rollup-plugin-vue';
+
+const { dependencies = {}, peerDependencies = {} } = packageJson;
+
+const externals = Object.keys(
+  Object.assign({}, dependencies, peerDependencies),
+);
+
+const nodeModules = path.resolve('./node_modules');
+
+export default {
+  input: './src/index.js',
+  output: [
+    {
+      sourcemap: true,
+      dir: './dist',
+      format: 'cjs',
+      entryFileNames: '[name].js'
+    },
+    {
+      sourcemap: true,
+      dir: './dist',
+      format: 'es',
+      entryFileNames: '[name].esm.js'
+    },
+  ],
+  external: id => externals.some(dep => dep === id || id.startsWith(`${dep}/`)),
+  onwarn(warning) {
+    if (warning.code === 'UNRESOLVED_IMPORT') throw new Error(warning.message);
+    // eslint-disable-next-line no-console
+    console.warn(warning.message);
+  },
+  plugins: [
+    babel({
+      exclude: nodeModules,
+      runtimeHelpers: true,
+    }),
+    rollupPluginCommonjs({
+      extensions: ['.js',],
+    }),
+    resolve({
+      extensions: ['.mjs', '.js', '.vue'],
+    }),
+    postcss({
+      extract: path.resolve('./dist/index.css'),
+      inject: false,
+      plugins: [autoprefixer()],
+      // uncomment the modules property if you want to import css module files into your js instead of SFC styles
+      // modules: {
+      //   generateScopedName:
+      //     process.env.NODE_ENV === 'dev'
+      //       ? '[name]-[local]'
+      //       : '[md5:hash:base64:16]',
+      // },
+    }),
+    VuePlugin({
+      needMap: false,
+      css: false,
+      style: {
+        generateScopedName:
+          process.env.NODE_ENV === 'dev' ? '[name]-[local]' : '[md5:hash:base64:16]',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
I think we were too hasty in taking out the build option:

- There was a mistake in the `package.json` (my mistake) that was pointing to the wrong `module` file, which could explain why these components weren't being properly tree-shaken.

- I strongly believe we should not be shipping nonstandard syntax for components that are meant to be shared and reused. The build can always be updated, but we should be targeting standards for distribution.

- we're exporting the `src` directory already, so if an author wants to pull in the `vue` files directly they have that option