### PR TITLE
Fix scss imports in rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ This is a template for building REI components using `@vue/cli` with the legacy 
 
 ### Usage
 ``` bash
-$ npm install -g @vue/cli
-$ npm install -g @vue/cli-init
+$ npm install -g @vue/cli @vue/cli-init
 $ vue init rei/component your-component-name
 $ cd your-component-name
 $ npm install

--- a/template/package.json
+++ b/template/package.json
@@ -31,8 +31,8 @@
     "test-vue-watch": "vunit --spec='./src/main/js/test/**/*.vue.spec.js' --watch=src/main/js"
   },
   "peerDependencies": {
-    "@rei/cedar": "^2.0.2",
-    "@rei/cdr-tokens": "^1.1.1",
+    "@rei/cedar": "^3.0.4",
+    "@rei/cdr-tokens": "^2.0.0",
     "vue": "^2.6.10"
   },
   "devDependencies": {
@@ -40,8 +40,8 @@
     "@babel/preset-env": "^7.5.5",
     "@babel/runtime": "^7.5.5",
     "@rei/browserslist-config": "^1.0.4",
-    "@rei/cedar": "^2.0.2",
-    "@rei/cdr-tokens": "^1.1.1",
+    "@rei/cedar": "^3.0.4",
+    "@rei/cdr-tokens": "^2.0.0",
     "@rei/febs": "^5.4.0",
     "@rei/vunit": "^2.0.0",
     "@vue/test-utils": "^1.0.0-beta.29",

--- a/template/package.json
+++ b/template/package.json
@@ -13,7 +13,7 @@
   "browserslist": "extends @rei/browserslist-config",
   "license": "UNLICENSED",
   "scripts": {
-    "dev:server": "cross-env NODE_ENV=dev febs dev",
+    "dev:server": "febs dev",
     "dev:build": "cross-env NODE_ENV=dev BABEL_ENV=es rollup -c --watch",
     "dev:clean": "rimraf dist && npm run dev",
     "dev": "npm-run-all -p dev:build dev:server",

--- a/template/rollup.config.js
+++ b/template/rollup.config.js
@@ -67,6 +67,14 @@ export default {
       style: {
         generateScopedName:
           process.env.NODE_ENV === 'dev' ? '[name]-[local]' : '[md5:hash:base64:16]',
+        preprocessOptions: {
+          scss: {
+            includePaths: ['node_modules/', 'src/'],
+            importer(path) {
+              return { file: path[0] !== '~' ? path : path.slice(1) };
+            }
+          },
+        },
       },
     }),
   ],

--- a/template/src/components/Component.vue
+++ b/template/src/components/Component.vue
@@ -13,5 +13,5 @@ export default {
 </script>
 
 <style lang="scss">
-@import '../globals.scss';
+@import '~@rei/cdr-tokens/dist/scss/cdr-tokens.scss';
 </style>

--- a/template/src/components/SampleChildComponent.vue
+++ b/template/src/components/SampleChildComponent.vue
@@ -1,11 +1,10 @@
 <script>
-import { CdrText, CdrAccordion, CdrAccordionItem } from '@rei/cedar';
+import { CdrText, CdrAccordion } from '@rei/cedar';
 
 export default {
   name: 'SampleChildComponent',
   components: {
     CdrAccordion,
-    CdrAccordionItem,
     CdrText,
   },
   props: {
@@ -33,17 +32,16 @@ export default {
       {{ accordionLabel }}
     </cdr-text>
     <div v-if="faqs">
-      <cdr-accordion :compact="true">
-        <cdr-accordion-item
-          v-for="(faq, i) in cleanedFaqs"
-          :id="`faq-item-${i}`"
-          :key="`faq-${i}`"
-          :label="faq.question"
-        >
-          <cdr-text tag="p">
-            {{ faq.answer }}
-          </cdr-text>
-        </cdr-accordion-item>
+      <cdr-accordion
+        v-for="(faq, i) in cleanedFaqs"
+        :id="`faq-item-${i}`"
+        :key="`faq-${i}`"
+        :label="faq.question"
+        :compact="true"
+      >
+        <cdr-text tag="p">
+          {{ faq.answer }}
+        </cdr-text>
       </cdr-accordion>
     </div>
     <div v-else>

--- a/template/src/components/SampleComponent.vue
+++ b/template/src/components/SampleComponent.vue
@@ -81,8 +81,7 @@ export default {
   </div>
 </template>
 <style lang="scss">
-@import '../globals.scss';
-// cedar tokens imported into globals.scss available here
+@import '~@rei/cdr-tokens/dist/scss/cdr-tokens.scss';
 .cdr-button {
   &__icon {
     fill: $cdr-color-icon-emphasis-darkmode;

--- a/template/src/globals.scss
+++ b/template/src/globals.scss
@@ -1,1 +1,0 @@
-@import '../node_modules/@rei/cdr-tokens/dist/scss/cdr-tokens.scss';


### PR DESCRIPTION
webpack/postcss expects scss imports to look like this `@import '~@rei/cedar/etc.'` whereas rollup-plugin-vue expects them to look like this:  `@import '@rei/cedar/etc.'`.  This rollup config change makes tilde style imports work in .vue

https://github.com/vuejs/rollup-plugin-vue/issues/299 (rollup-plugin-vue compiles styles internally rather than passing them on to rollup-plugin-postcss, which is why we need to configure the alias inside that plugin)
https://github.com/vuejs/rollup-plugin-vue/issues/300 

Another possible way to get around this is to always do your SCSS node_modules imports in an actual `.scss` file and not in a `.vue` style block, as that way postcss processes your file instead of rollup-plugin-vue which bypasses the issue (i.e, import the tokens into a globals.scss file and import that everywhere you need the cdr-tokens). This seems like a weird gotcha, as it makes SCSS imports behave differently depending on whether its an `.scss` file of inside of a `.vue` style block.  (this is what this component template was previously doing with the globals.scss file, and is also how the product-page team has solved this issue). It also basically forces people to write a wrapper SCSS file just to import styles from node_modules.

- add alias to rollup-plugin-vue style processor to make webpack style imports work
- updates cedar version, updates accordion example
- remove `NODE_ENV` from febs command 