### PR TITLE
Cedar summer 2020

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -39,11 +39,11 @@
     "@vue/test-utils": "^1.0.0",
     "babel-plugin-istanbul": "^6.0.0",
     "chai": "^4.2.0",
-    "eslint": "^6.1.0",
+    "eslint": "^7.7.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-vue": "^6.2.1",
     "npm-run-all": "^4.1.5",
-    "rimraf": "^2.6.0"
+    "rimraf": "^3.0.2"
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -35,10 +35,9 @@
   "devDependencies": {
     "@rei/cdr-tokens": "^5.0.0",
     "@rei/febs": "^7.1.0",
-    "@rei/vunit": "^2.1.4",
+    "@rei/vunit": "^3.0.0",
     "@vue/test-utils": "^1.0.0",
     "babel-plugin-istanbul": "^6.0.0",
-    "chai": "^4.2.0",
     "eslint": "^7.7.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.20.1",

--- a/template/package.json
+++ b/template/package.json
@@ -27,13 +27,13 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@babel/runtime-corejs3": "^7.8.4",
-    "@rei/cedar": "^5.0.0"
+    "@rei/cedar": "^6.0.0"
   },
   "peerDependencies": {
     "vue": "^2.6.10"
   },
   "devDependencies": {
-    "@rei/cdr-tokens": "^4.0.0",
+    "@rei/cdr-tokens": "^5.0.0",
     "@rei/febs": "^7.1.0",
     "@rei/vunit": "^2.1.4",
     "@vue/test-utils": "^1.0.0",

--- a/template/src/Component.vue
+++ b/template/src/Component.vue
@@ -2,14 +2,14 @@
   <div>
     <cdr-text
       tag="h1"
-      class="cdr-align-text-center"
-      modifier="heading-serif-strong-700"
+      class="header cdr-align-text-center"
     >
       {{ title }}
     </cdr-text>
-    <cdr-text modifier="body-300">
+    <cdr-text class="body">
       {{ description }}
     </cdr-text>
+    <cdr-link href="rei.com">homepage</cdr-link>
   </div>
 </template>
 
@@ -30,4 +30,11 @@ export default {
 
 <style lang="scss">
 @import '~@rei/cdr-tokens/dist/scss/cdr-tokens.scss';
+.header {
+  @include cdr-text-heading-serif-strong-700;
+}
+
+.body {
+  @include cdr-text-body-300;
+}
 </style>

--- a/template/src/main.scss
+++ b/template/src/main.scss
@@ -1,5 +1,9 @@
 /* import Cedar component CSS used in this package */
-@import url("@rei/cedar/dist/style/cdr-text.css");
+@import url("@rei/cedar/dist/style/cdr-link.css");
+
+// cdr-text CSS not imported as component uses text mixins instead of utility classes
+// @import url("@rei/cedar/dist/style/cdr-text.css");
+
 /* import Cedar utility class files used in this package */
 @import url("@rei/cedar/dist/style/align.css");
 /* for more info: https://rei.github.io/rei-cedar-docs/getting-started/as-a-developer/#include-component-and-utility-css */

--- a/template/test/Component.spec.js
+++ b/template/test/Component.spec.js
@@ -1,5 +1,4 @@
 import { mount } from '@vue/test-utils';
-import { expect } from 'chai';
 
 import MainComponent from '../src/{{pascalcase name}}.vue';
 

--- a/template/test/unit.spec.js
+++ b/template/test/unit.spec.js
@@ -1,5 +1,3 @@
-import { expect } from 'chai';
-
 describe('Example unit test', () => {
   function double(x) {
     return x * 2;


### PR DESCRIPTION
- updates eslint and rimraf dependencies
- updates cedar/cdr-tokens versions
- update example code to emphasize using cdr-text with tokens instead of modifiers/utilities
- updates vunit, removes chai dependency (its loaded automatically by vunit 3.0.0)