### PR TITLE
Adding missing CdrLink import to component template

### DIFF
--- a/template/src/Component.vue
+++ b/template/src/Component.vue
@@ -14,12 +14,13 @@
 </template>
 
 <script>
-import { CdrText } from '@rei/cedar';
+import { CdrText, CdrLink } from '@rei/cedar';
 
 export default {
   name: 'MainComponent',
   components: {
     CdrText,
+    CdrLink,
   },
   props: {
     title: String,


### PR DESCRIPTION
Just noticed the sample component was using `CdrLink` but didn't actually import it.