### PR TITLE
update for cedar winter release

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -27,13 +27,13 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@babel/runtime-corejs3": "^7.8.4",
-    "@rei/cedar": "^7.0.0"
+    "@rei/cedar": "^8.0.0"
   },
   "peerDependencies": {
     "vue": "^2.6.10"
   },
   "devDependencies": {
-    "@rei/cdr-tokens": "^7.0.0",
+    "@rei/cdr-tokens": "^8.0.0",
     "@rei/febs": "^8.0.0",
     "@rei/vunit": "^3.0.0",
     "@vue/test-utils": "^1.0.0",

--- a/template/src/main.scss
+++ b/template/src/main.scss
@@ -1,2 +1,3 @@
 /* import any shared component CSS used in this package */
 @import url("@rei/cedar/dist/style/cdr-link.css");
+@import url("@rei/cedar/dist/style/cdr-text.css");


### PR DESCRIPTION
- update cedar deps
- import cdr-text.css file. We split up the gigantic text.css file into one that just has the minimal default text styles (cdr-text.css) and another that has the whole type scale (text.css).