### PR TITLE
bump major versions of deps

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -27,13 +27,13 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@babel/runtime-corejs3": "^7.8.4",
-    "@rei/cedar": "^8.0.0"
+    "@rei/cedar": "^9.0.0"
   },
   "peerDependencies": {
     "vue": "^2.6.10"
   },
   "devDependencies": {
-    "@rei/cdr-tokens": "^8.0.0",
+    "@rei/cdr-tokens": "^9.0.0",
     "@rei/febs": "^8.1.0",
     "@rei/vunit": "^4.1.0",
     "@vue/test-utils": "^1.0.0",

--- a/template/package.json
+++ b/template/package.json
@@ -34,14 +34,14 @@
   },
   "devDependencies": {
     "@rei/cdr-tokens": "^8.0.0",
-    "@rei/febs": "^8.0.0",
-    "@rei/vunit": "^3.0.0",
+    "@rei/febs": "^8.1.0",
+    "@rei/vunit": "^4.1.0",
     "@vue/test-utils": "^1.0.0",
     "babel-plugin-istanbul": "^6.0.0",
     "eslint": "^7.7.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.20.1",
-    "eslint-plugin-vue": "^6.2.1",
+    "eslint-plugin-vue": "^7.1.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2"
   }


### PR DESCRIPTION
minor/patch updates will get picked up whenever `npm install` is run for the first time as this template does not distribute a package-lock